### PR TITLE
chore: remove cloudXR IpStackApiToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,6 @@ The instance (customer). Defaults to `instance_name` variable.
 
 The sentry DSN
 
-    cloudxr_ip_stack_api_token:
-
-**Mandatory** The IP address lookup is required to select the closest cloudXR region. The token must be obtained on [this](https://ipstack.com/) website
-
     cloudxr_azure_enabled:
 
 **Mandatory if azure** enable azure integration. This option is mutually exclusive with `cloudxr_aws_enabled`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,7 +124,6 @@ cloudxr_default_region:
 cloudxr_instance:
 cloudxr_machine_max_keep_alive_age:
 cloudxr_management_sentry_dsn:
-cloudxr_ip_stack_api_token:
 cloudxr_azure_enabled:
 cloudxr_azure_client_id:
 cloudxr_azure_secret:
@@ -143,7 +142,6 @@ cloudxr_configuration:
   instance: "{{ cloudxr_instance }}"
   max_keep_avlive_age: "{{ cloudxr_machine_max_keep_alive_age }}"
   sentry_dsn: "{{ cloudxr_management_sentry_dsn }}"
-  ip_stack_api_token: "{{ cloudxr_ip_stack_api_token }}"
 
   azure_enabled: "{{ cloudxr_azure_enabled | default('false', true) }}"
   azure_client_id: "{{ cloudxr_azure_client_id | default('false', true) }}"
@@ -163,7 +161,7 @@ session_management_log_level:
 session_management_cors_origin:
 session_management_oauth_client_id:
 session_management_oauth_client_secret:
-session_management_ip_stack_api_token: "{{ cloudxr_configuration.ip_stack_api_token }}"
+session_management_ip_stack_api_token:
 session_management_adaptive_instance_scaling_enabled: true
 session_management_adaptive_instance_scaling_user_scale_ratio: 1
 session_management_adaptive_instance_scaling_max_instances_per_region: 5

--- a/tasks/cloudxr_management_service.yml
+++ b/tasks/cloudxr_management_service.yml
@@ -11,7 +11,6 @@
     env:
       Instance: "{{ cloudxr_configuration.instance }}"
       MachineMaxKeepAliveAge: "{{ cloudxr_configuration.max_keep_avlive_age }}"
-      IpStackApiToken: "{{ cloudxr_configuration.ip_stack_api_token }}"
       Sentry__Dsn: "{{ cloudxr_configuration.sentry_dsn }}"
       Sentry__ServerName: "{{ cloudxr_configuration.instance }}"
       DefaultRegion: "{{ cloudxr_configuration.defaultRegion }}"


### PR DESCRIPTION
since we removed the config from the container already, we can also just remove it from the role too.